### PR TITLE
Add missing status variable for download failure

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,8 +90,8 @@ ArtifactoryResolver.prototype._resolve = function () {
                     });
             })
             .fail(function (response) {
-
-            var notFound = response.message.lastIndexOf(" 404") + 4 == response.message.length;
+                var status = response.statusCode;
+                var notFound = response.message.lastIndexOf(" 404") + 4 == response.message.length;
                 // In case we got 404, lets take the full error JSON, and show it to the user
                 if (notFound) {
                     return ArtifactoryResolver.doArtifactoryRequest(requestUrl, Config)


### PR DESCRIPTION
On download failure, the status variable is undefined and would blow up.  This adds the status variable definition
