### PR TITLE
Properly pass config object.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,7 @@ ArtifactoryResolver.prototype._resolve = function () {
             var notFound = response.message.lastIndexOf(" 404") + 4 == response.message.length;
                 // In case we got 404, lets take the full error JSON, and show it to the user
                 if (notFound) {
-                    return ArtifactoryResolver.doArtifactoryRequest(requestUrl, Config)
+                    return ArtifactoryResolver.doArtifactoryRequest(requestUrl, that._config)
                         .then(function (response) {
                             var jsonObject = JSON.parse(response);
                             var message = jsonObject.errors[0].message;


### PR DESCRIPTION
We do pass the config object so we can use it for things like proxy or
SSL verification when doing requests. In a call to
`doArtifactoryRequest` it was not properly passed so the settings were
not used in one of the error case handlers.

This patch fixes the call to `doArtifactoryRequest`.
